### PR TITLE
Bugfix when comparing to undefined

### DIFF
--- a/samigo/samigo-app/src/webapp/js/utils-emi.js
+++ b/samigo/samigo-app/src/webapp/js/utils-emi.js
@@ -67,7 +67,7 @@ function isValidOption(element, validEMIOptions, charCode){
 		return false;
 	}
 	// now check that it is not a duplicate
-	if (typeof element.value === undefined) {
+	if (typeof element.value === 'undefined') {
 		element.value = element.val();
 	}
 	var index = element.value.toUpperCase().indexOf(keychar);


### PR DESCRIPTION
Using Google bigquery I found that your code was comparing the result of `typeof` with a variable named `undefined`.

As typeof returns a string it would compare to a string with the content `'undefined'`